### PR TITLE
Possible routing fix

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,11 @@
         "distDir": "dist"
       }
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
There is a bug when navigating directly to one of the subpages:
![image](https://github.com/user-attachments/assets/15f013f2-0c08-4a19-9719-2d1004791665)
