### PR TITLE
Show percentage unit more clearly in diagrams

### DIFF
--- a/components/graphs/LineChart.tsx
+++ b/components/graphs/LineChart.tsx
@@ -131,6 +131,11 @@ const LineChart = ({ onlineFondet, osebx }: Props) => {
       legend: {
         position: 'top' as const,
       },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => `${Math.round(ctx.raw * 100) / 100}%`
+        }
+      },
     },
     scales: {
       y: {

--- a/components/graphs/PieChart.tsx
+++ b/components/graphs/PieChart.tsx
@@ -18,7 +18,6 @@ const PieChart = ({ composition }: Props) => {
     labels: labels,
     datasets: [
       {
-        label: 'Prosent',
         data: dataValues,
         backgroundColor: [
           'rgba(255, 99, 132, 0.6)',
@@ -56,7 +55,12 @@ const PieChart = ({ composition }: Props) => {
       legend: {
         position: 'top' as const,
       },
-    },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => `${Math.round(ctx.raw * 100) / 100}%`
+        }
+      },
+    }
   };
 
   return (


### PR DESCRIPTION
This makes the units more clear on the website. This is especially important in the line graph because the number which right now displays as "247.473" (which means 247.473%) can easily be confused for an absolute number (247 473kr). 


## Før:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/cbd417fb-34e8-4132-9a81-711e36ba4df4">

## Etter:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/f10925e1-a60c-4b53-a13d-49ac210200c6">

## Før:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/5a8a85fc-19c3-43d8-be86-9ea2f1a14844">

## Etter:

<img width="596" alt="image" src="https://github.com/user-attachments/assets/66e4bc33-69d9-4553-af3e-e520aa230b1f">

